### PR TITLE
change "error" to "inline" in hook_names list in html_notebook.R

### DIFF
--- a/R/html_notebook.R
+++ b/R/html_notebook.R
@@ -342,7 +342,7 @@ html_notebook_knitr_options <- function() {
 
   # generic hooks for knitr output
   hook_names <- c("source", "chunk", "plot", "text", "output",
-                 "warning", "error", "message", "error")
+                 "warning", "inline", "message", "error")
 
   meta_hooks <- list(
     source  = html_notebook_text_hook,


### PR DESCRIPTION
I think this might fix the thing.